### PR TITLE
Fix: TravelMateJoinRequest 서비스 테스트 코드 의존성 누락

### DIFF
--- a/src/test/java/com/ganzi/soccerhub/trip/application/service/AddTravelMateJoinRequestServiceTest.java
+++ b/src/test/java/com/ganzi/soccerhub/trip/application/service/AddTravelMateJoinRequestServiceTest.java
@@ -6,6 +6,7 @@ import com.ganzi.soccerhub.trip.application.command.AddTravelMateJoinRequestComm
 import com.ganzi.soccerhub.trip.application.exception.PostParticipationNotAllowedException;
 import com.ganzi.soccerhub.trip.application.port.in.AddTravelMateJoinRequestUseCase;
 import com.ganzi.soccerhub.trip.application.port.out.AddTravelMateJoinRequestPort;
+import com.ganzi.soccerhub.trip.application.port.out.LoadTravelMateJoinRequestPort;
 import com.ganzi.soccerhub.trip.application.port.out.LoadTravelMatePostPort;
 import com.ganzi.soccerhub.trip.domain.TravelMateJoinRequest;
 import com.ganzi.soccerhub.trip.domain.TravelMatePost;
@@ -13,6 +14,7 @@ import com.ganzi.soccerhub.user.application.port.out.LoadUserPort;
 import com.ganzi.soccerhub.user.domain.User;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Optional;
 
@@ -25,10 +27,18 @@ import static org.mockito.Mockito.verify;
 public class AddTravelMateJoinRequestServiceTest {
 
     private final LoadTravelMatePostPort loadTravelMatePostPort = Mockito.mock(LoadTravelMatePostPort.class);
+    private final LoadTravelMateJoinRequestPort loadTravelMateJoinRequestPort = Mockito.mock(LoadTravelMateJoinRequestPort.class);
     private final AddTravelMateJoinRequestPort addTravelMateJoinRequestPort = Mockito.mock(AddTravelMateJoinRequestPort.class);
     private final LoadUserPort loadUserPort = Mockito.mock(LoadUserPort.class);
+    private final ApplicationEventPublisher applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
 
-    private final AddTravelMateJoinRequestUseCase addTravelMateJoinRequestUseCase = new AddTravelMateJoinRequestService(loadTravelMatePostPort, addTravelMateJoinRequestPort, loadUserPort);
+    private final AddTravelMateJoinRequestUseCase addTravelMateJoinRequestUseCase = new AddTravelMateJoinRequestService(
+            loadTravelMatePostPort,
+            loadTravelMateJoinRequestPort,
+            addTravelMateJoinRequestPort,
+            loadUserPort,
+            applicationEventPublisher
+    );
 
     @Test
     void add_shouldSucceed() {


### PR DESCRIPTION
## 🧾 개요
TravelMateJoinRequestService 클래스 의존성 추가되었으나 테스트 코드에 반영하지 않아 반영함

---

## ✅ 작업 내용
- [ ] TravelMateJoinRequestServiceTest - TravelMateJoinRequestService 의존성 추가

---

## 🏷️ 관련 태그 (선택)
`버그 수정`
